### PR TITLE
fix:修复函数章节一个斜体渲染问题

### DIFF
--- a/source/02_language_guide/06_Functions.md
+++ b/source/02_language_guide/06_Functions.md
@@ -293,7 +293,7 @@ someFunction(parameterWithoutDefault: 4) // parameterWithDefault = 12
 
 ### 可变参数 {#variadic-parameters}
 
-一个*可变参数（variadic parameter）*可以接受零个或多个值。函数调用时，你可以用可变参数来指定函数参数可以被传入不确定数量的输入值。通过在变量类型名后面加入（`...`）的方式来定义可变参数。
+一个*可变参数（variadic parameter）* 可以接受零个或多个值。函数调用时，你可以用可变参数来指定函数参数可以被传入不确定数量的输入值。通过在变量类型名后面加入（`...`）的方式来定义可变参数。
 
 可变参数的传入值在函数体中变为此类型的一个数组。例如，一个叫做 `numbers` 的 `Double...` 型可变参数，在函数体内可以当做一个叫 `numbers` 的 `[Double]` 型的数组常量。
 


### PR DESCRIPTION
在第二个*号后面加个空格就能正常渲染斜体了，具体为什么这么做会起作用不了解。